### PR TITLE
fix: wrong memory address when updating channel

### DIFF
--- a/channel/token-store.go
+++ b/channel/token-store.go
@@ -167,7 +167,7 @@ func TokenStoreRemoveChannel(channel *model.Channel) {
 	}
 }
 
-func TokenStoreUpdateChannel(newChannel model.Channel, oldChannel *model.Channel) {
+func TokenStoreUpdateChannel(newChannel *model.Channel, oldChannel *model.Channel) {
 	if oldChannel.Type != model.TypeWeChatTestAccount && oldChannel.Type != model.TypeWeChatCorpAccount {
 		return
 	}

--- a/channel/token-store.go
+++ b/channel/token-store.go
@@ -167,7 +167,7 @@ func TokenStoreRemoveChannel(channel *model.Channel) {
 	}
 }
 
-func TokenStoreUpdateChannel(newChannel *model.Channel, oldChannel *model.Channel) {
+func TokenStoreUpdateChannel(newChannel model.Channel, oldChannel *model.Channel) {
 	if oldChannel.Type != model.TypeWeChatTestAccount && oldChannel.Type != model.TypeWeChatCorpAccount {
 		return
 	}

--- a/controller/channel.go
+++ b/controller/channel.go
@@ -191,7 +191,7 @@ func UpdateChannel(c *gin.Context) {
 		})
 		return
 	}
-	channel.TokenStoreUpdateChannel(cleanChannel, oldChannel)
+	channel.TokenStoreUpdateChannel(&cleanChannel, oldChannel)
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",

--- a/controller/channel.go
+++ b/controller/channel.go
@@ -1,12 +1,13 @@
 package controller
 
 import (
-	"github.com/gin-gonic/gin"
 	"message-pusher/channel"
 	"message-pusher/common"
 	"message-pusher/model"
 	"net/http"
 	"strconv"
+
+	"github.com/gin-gonic/gin"
 )
 
 func GetAllChannels(c *gin.Context) {
@@ -168,7 +169,7 @@ func UpdateChannel(c *gin.Context) {
 		})
 		return
 	}
-	cleanChannel := oldChannel
+	cleanChannel := *oldChannel
 	if statusOnly != "" {
 		cleanChannel.Status = channel_.Status
 	} else {


### PR DESCRIPTION
Fix the address issue when updating the Wecom channel detail
修复原代码无法修改被添加的企业微信应用号通道的问题
### 复现过程
在通道中新增一个企业微信应用，填入（错误的）资料，保存后再进行修改 `Secret`，在 `AppId` 相同的情况下，这一行代码会将原来内存引用的 `oldChannel` 变量中的 `AppId` 也删除，因此在调用 `parseWechatCorpAccountAppId` 方法时会传入空值，返回错误 “无效的微信企业号配置”
https://github.com/songquanpeng/message-pusher/blob/39da3f977148b0bed6ef762f976757832176789f/channel/token-store.go#L178