### PR TITLE
fix: resolve message sending failure when containing "\n" using webhook and custom channel

### DIFF
--- a/channel/custom.go
+++ b/channel/custom.go
@@ -18,11 +18,11 @@ func SendCustomMessage(message *model.Message, user *model.User, channel_ *model
 		return errors.New("自定义通道不能使用本服务地址")
 	}
 	template := channel_.Other
-	template = strings.Replace(template, "$url", message.URL, -1)
-	template = strings.Replace(template, "$to", message.To, -1)
-	template = strings.Replace(template, "$title", message.Title, -1)
-	template = strings.Replace(template, "$description", message.Description, -1)
-	template = strings.Replace(template, "$content", message.Content, -1)
+	template = common.Replace(template, "$url", message.URL, -1)
+	template = common.Replace(template, "$to", message.To, -1)
+	template = common.Replace(template, "$title", message.Title, -1)
+	template = common.Replace(template, "$description", message.Description, -1)
+	template = common.Replace(template, "$content", message.Content, -1)
 	reqBody := []byte(template)
 	resp, err := http.Post(url, "application/json", bytes.NewReader(reqBody))
 	if err != nil {

--- a/common/utils.go
+++ b/common/utils.go
@@ -159,3 +159,8 @@ func Markdown2HTML(markdown string) (HTML string, err error) {
 func GetTimestamp() int64 {
 	return time.Now().Unix()
 }
+
+func Replace(s, old, new string, n int) string {
+	new = strings.TrimPrefix(strings.TrimSuffix(fmt.Sprintf("%q", new), "\""), "\"")
+	return strings.Replace(s, old, new, n)
+}

--- a/common/utils.go
+++ b/common/utils.go
@@ -150,7 +150,10 @@ func Markdown2HTML(markdown string) (HTML string, err error) {
 	}
 	var buf bytes.Buffer
 	goldMarkEntity := goldmark.New(
-		goldmark.WithExtensions(extension.GFM),
+		goldmark.WithExtensions(
+			extension.GFM,
+			extension.Footnote,
+		),
 	)
 	err = goldMarkEntity.Convert([]byte(markdown), &buf)
 	if err != nil {

--- a/common/utils.go
+++ b/common/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
 	"html/template"
 	"log"
 	"net"
@@ -148,7 +149,10 @@ func Markdown2HTML(markdown string) (HTML string, err error) {
 		return "", nil
 	}
 	var buf bytes.Buffer
-	err = goldmark.Convert([]byte(markdown), &buf)
+	goldMarkEntity := goldmark.New(
+		goldmark.WithExtensions(extension.GFM),
+	)
+	err = goldMarkEntity.Convert([]byte(markdown), &buf)
 	if err != nil {
 		return fmt.Sprintf("Markdown 渲染出错：%s", err.Error()), err
 	}

--- a/controller/webhook.go
+++ b/controller/webhook.go
@@ -240,7 +240,7 @@ func TriggerWebhook(c *gin.Context) {
 	}
 	for key, value := range extractRule {
 		variableValue := gjson.Get(reqText, value).String()
-		webhook.ConstructRule = strings.Replace(webhook.ConstructRule, "$"+key, variableValue, -1)
+		webhook.ConstructRule = common.Replace(webhook.ConstructRule, "$"+key, variableValue, -1)
 	}
 	constructRule := model.WebhookConstructRule{}
 	err = json.Unmarshal([]byte(webhook.ConstructRule), &constructRule)

--- a/web/src/components/MessagesTable.js
+++ b/web/src/components/MessagesTable.js
@@ -5,6 +5,7 @@ import { API, openPage, showError, showSuccess, showWarning } from '../helpers';
 import { ITEMS_PER_PAGE } from '../constants';
 import { renderTimestamp } from '../helpers/render';
 import { Link } from 'react-router-dom';
+import { marked } from 'marked';
 
 function renderStatus(status) {
   switch (status) {
@@ -416,7 +417,7 @@ const MessagesTable = () => {
           ) : (
             ''
           )}
-          {message.content ? <p>{message.content}</p> : ''}
+          {message.content ? <div dangerouslySetInnerHTML={{ __html: marked.parse(message.content) }}></div> : ''}
         </Modal.Content>
         <Modal.Actions>
           <Button


### PR DESCRIPTION
`strings.Replace()`会将`content`和`description`中的`\n`给替换成代码的换行符，导致在webhook的json解析时报错，同时普通通道的传递给第三方接口的json也会出现问题，导致消息发送失败。

我是使用webhook和gotify进行配置发送消息，使用webhook接口时，会提示“Webhook 构建规则解析失败”，使用后台推送消息时，会提示400错误。经过问题排查，锁定在了json模板的替换上，经过代码修改，本地测试后修复了问题。

由于在[教程](https://iamazing.cn/page/message-pusher-webhook)中的github我还没有接入体验过，所以我不确定这个问题原先是否就已经存在。

## 错误实现

添加一个webhook接口，提取规则和构建规则保持默认。

```json
# 提取规则
{
  "title": "attr1",
  "description": "attr2.sub_attr",
  "content": "attr3",
  "url": "attr4"
}
# 构建规则
{
  "title": "$title",
  "description": "描述信息：$description",
  "content": "内容：$content",
  "url": "https://example.com/$title"
}
```

使用postman进行接口调试，当请求体包含`\n`是，会提示推送失败。
```json
# 请求内容
{
  "attr1": "这是一个测试标题",
  "attr2": {
    "sub_attr": "这是描述内容"
  },
  "attr3": "## 这是内容\n\n具体的内容是**这样**的",
  "attr4": "https://example.com"
}
# 请求结果
{
  "message": "Webhook 构建规则解析失败",
  "success": false
}
```

