### PR TITLE
feat: 添加带单元测试的 Bash 示例

### DIFF
--- a/examples/bash/README.md
+++ b/examples/bash/README.md
@@ -1,0 +1,212 @@
+# Message Pusher Bash Example
+
+Bash 示例脚本，展示如何使用 Message Pusher API 发送消息。
+
+## 要求
+
+- Bash 4.0 或更高版本
+- curl（HTTP 客户端）
+- jq（JSON 处理工具）
+
+## 快速开始
+
+### 1. 安装依赖
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install curl jq
+
+# CentOS/RHEL
+sudo yum install curl jq
+
+# macOS
+brew install curl jq
+```
+
+### 2. 赋予执行权限
+
+```bash
+chmod +x message_pusher.sh
+chmod +x test_message_pusher.sh
+```
+
+### 3. 运行示例
+
+```bash
+./message_pusher.sh "标题" "描述" "**Markdown 内容**"
+```
+
+### 4. 运行测试
+
+```bash
+./test_message_pusher.sh
+```
+
+## 项目结构
+
+```
+.
+├── message_pusher.sh       # 主脚本
+├── test_message_pusher.sh  # 测试脚本
+└── README.md               # 本文件
+```
+
+## 功能特性
+
+### message_pusher.sh
+- ✅ 支持 JSON 和 Form 两种请求方式
+- ✅ 支持从管道读取内容
+- ✅ 支持指定推送通道
+- ✅ 环境变量配置
+- ✅ 彩色输出
+- ✅ 完整的错误处理
+- ✅ 详细的帮助信息
+
+### test_message_pusher.sh
+- ✅ 依赖检查测试
+- ✅ 环境变量测试
+- ✅ 参数解析测试
+- ✅ JSON 构建测试
+- ✅ 彩色测试结果输出
+- ✅ 12 个测试全部通过
+
+## 使用方法
+
+### 基本用法
+
+```bash
+# JSON 方式（默认）
+./message_pusher.sh "标题" "描述" "**Markdown 内容**"
+
+# Form 方式
+./message_pusher.sh --form "标题" "描述" "内容"
+```
+
+### 指定推送通道
+
+```bash
+./message_pusher.sh --channel email "标题" "描述" "内容"
+```
+
+### 从管道读取内容
+
+```bash
+# 发送命令输出
+echo "系统状态正常" | ./message_pusher.sh --pipe "系统监控"
+
+# 发送文件内容
+cat /var/log/syslog | tail -n 20 | ./message_pusher.sh --pipe "系统日志"
+
+# 发送系统信息
+uname -a | ./message_pusher.sh --pipe "系统信息"
+```
+
+### 使用环境变量
+
+```bash
+export MESSAGE_PUSHER_SERVER="https://push.justsong.cn"
+export MESSAGE_PUSHER_USERNAME="your_username"
+export MESSAGE_PUSHER_TOKEN="your_token"
+
+./message_pusher.sh "标题" "描述" "内容"
+```
+
+## 测试
+
+项目包含完整的测试脚本。
+
+运行所有测试：
+```bash
+./test_message_pusher.sh
+```
+
+测试内容：
+- ✅ 依赖检查（curl, jq）
+- ✅ 环境变量设置
+- ✅ 参数解析
+- ✅ JSON 数据构建
+- ✅ 帮助信息显示
+
+## 配置
+
+### 环境变量
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `MESSAGE_PUSHER_SERVER` | 服务器地址 | `https://push.justsong.cn` |
+| `MESSAGE_PUSHER_USERNAME` | 用户名 | `test` |
+| `MESSAGE_PUSHER_TOKEN` | 推送 Token | `666` |
+
+### 命令行选项
+
+| 选项 | 说明 |
+|------|------|
+| `-j, --json` | 使用 JSON 方式发送（默认） |
+| `-f, --form` | 使用 Form 方式发送 |
+| `-c, --channel NAME` | 指定推送通道 |
+| `-p, --pipe` | 从管道读取内容 |
+| `-h, --help` | 显示帮助信息 |
+
+## 实用示例
+
+### 1. 系统监控
+
+```bash
+#!/bin/bash
+source ./message_pusher.sh
+
+# 检查磁盘空间
+disk_usage=$(df -h / | tail -1 | awk '{print $5}' | sed 's/%//')
+if [ "$disk_usage" -gt 80 ]; then
+    send_message_json "⚠️ 磁盘空间警告" "系统监控" "磁盘使用率: ${disk_usage}%"
+fi
+```
+
+### 2. 备份通知
+
+```bash
+#!/bin/bash
+source ./message_pusher.sh
+
+if tar -czf /backup/data_$(date +%Y%m%d).tar.gz /data; then
+    send_message_json "✅ 备份成功" "数据备份" "备份文件: data_$(date +%Y%m%d).tar.gz"
+fi
+```
+
+### 3. Cron 任务集成
+
+```bash
+# 编辑 crontab
+crontab -e
+
+# 添加定时任务
+0 2 * * * /path/to/backup.sh 2>&1 | /path/to/message_pusher.sh --pipe "每日备份"
+```
+
+## 常见问题
+
+### Q: 如何调试脚本？
+A: 使用 bash 的调试模式：
+```bash
+bash -x ./message_pusher.sh "标题" "描述" "内容"
+```
+
+### Q: 如何处理特殊字符？
+A: 使用引号包裹参数：
+```bash
+./message_pusher.sh "标题" "描述" "包含 \"引号\" 的内容"
+```
+
+### Q: 如何发送多行内容？
+A: 使用 heredoc 或管道：
+```bash
+cat << EOF | ./message_pusher.sh --pipe "多行内容"
+第一行
+第二行
+第三行
+EOF
+```
+
+## 许可证
+
+与 Message Pusher 主项目保持一致

--- a/examples/bash/message_pusher.sh
+++ b/examples/bash/message_pusher.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+
+# Message Pusher Bash Client
+# 支持 JSON 和 Form 两种方式发送消息
+
+set -euo pipefail
+
+# 默认配置
+MESSAGE_PUSHER_SERVER="${MESSAGE_PUSHER_SERVER:-https://push.justsong.cn}"
+MESSAGE_PUSHER_USERNAME="${MESSAGE_PUSHER_USERNAME:-test}"
+MESSAGE_PUSHER_TOKEN="${MESSAGE_PUSHER_TOKEN:-666}"
+
+# 颜色输出
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# 打印错误信息
+error() {
+    echo -e "${RED}❌ 错误: $1${NC}" >&2
+}
+
+# 打印成功信息
+success() {
+    echo -e "${GREEN}✅ $1${NC}"
+}
+
+# 打印警告信息
+warning() {
+    echo -e "${YELLOW}⚠️  $1${NC}"
+}
+
+# 使用 JSON 方式发送消息
+# 参数: title description content [channel]
+send_message_json() {
+    local title="$1"
+    local description="$2"
+    local content="$3"
+    local channel="${4:-}"
+    
+    local url="${MESSAGE_PUSHER_SERVER}/push/${MESSAGE_PUSHER_USERNAME}"
+    
+    # 构建 JSON 数据
+    local json_data
+    if [ -n "$channel" ]; then
+        json_data=$(jq -n \
+            --arg title "$title" \
+            --arg description "$description" \
+            --arg content "$content" \
+            --arg token "$MESSAGE_PUSHER_TOKEN" \
+            --arg channel "$channel" \
+            '{title: $title, description: $description, content: $content, token: $token, channel: $channel}')
+    else
+        json_data=$(jq -n \
+            --arg title "$title" \
+            --arg description "$description" \
+            --arg content "$content" \
+            --arg token "$MESSAGE_PUSHER_TOKEN" \
+            '{title: $title, description: $description, content: $content, token: $token}')
+    fi
+    
+    # 发送请求
+    local response
+    response=$(curl -s -X POST "$url" \
+        -H "Content-Type: application/json" \
+        -d "$json_data")
+    
+    # 解析响应
+    local success
+    local message
+    success=$(echo "$response" | jq -r '.success')
+    message=$(echo "$response" | jq -r '.message')
+    
+    if [ "$success" = "true" ]; then
+        success "推送成功！"
+        return 0
+    else
+        error "推送失败：$message"
+        return 1
+    fi
+}
+
+# 使用 Form 方式发送消息
+# 参数: title description content
+send_message_form() {
+    local title="$1"
+    local description="$2"
+    local content="$3"
+    
+    local url="${MESSAGE_PUSHER_SERVER}/push/${MESSAGE_PUSHER_USERNAME}"
+    
+    # 发送请求
+    local response
+    response=$(curl -s -X POST "$url" \
+        -d "title=$title" \
+        -d "description=$description" \
+        -d "content=$content" \
+        -d "token=$MESSAGE_PUSHER_TOKEN")
+    
+    # 解析响应
+    local success
+    local message
+    success=$(echo "$response" | jq -r '.success')
+    message=$(echo "$response" | jq -r '.message')
+    
+    if [ "$success" = "true" ]; then
+        success "推送成功！"
+        return 0
+    else
+        error "推送失败：$message"
+        return 1
+    fi
+}
+
+# 从管道读取内容并发送
+send_from_pipe() {
+    local title="${1:-通知}"
+    local description="${2:-}"
+    
+    if [ -t 0 ]; then
+        error "没有从管道接收到内容"
+        return 1
+    fi
+    
+    local content
+    content=$(cat)
+    
+    send_message_json "$title" "$description" "$content"
+}
+
+# 显示帮助信息
+show_help() {
+    cat << EOF
+Message Pusher Bash Client
+
+用法:
+    $0 [选项] <标题> <描述> <内容>
+    echo "内容" | $0 --pipe [标题] [描述]
+
+选项:
+    -j, --json          使用 JSON 方式发送（默认）
+    -f, --form          使用 Form 方式发送
+    -c, --channel NAME  指定推送通道
+    -p, --pipe          从管道读取内容
+    -h, --help          显示此帮助信息
+
+环境变量:
+    MESSAGE_PUSHER_SERVER    服务器地址（默认: https://push.justsong.cn）
+    MESSAGE_PUSHER_USERNAME  用户名（默认: test）
+    MESSAGE_PUSHER_TOKEN     推送 Token（默认: 666）
+
+示例:
+    # JSON 方式
+    $0 "标题" "描述" "**Markdown 内容**"
+    
+    # Form 方式
+    $0 --form "标题" "描述" "内容"
+    
+    # 指定通道
+    $0 --channel email "标题" "描述" "内容"
+    
+    # 从管道读取
+    echo "系统状态正常" | $0 --pipe "系统监控"
+    uname -a | $0 --pipe "系统信息"
+
+EOF
+}
+
+# 主函数
+main() {
+    local method="json"
+    local channel=""
+    local use_pipe=false
+    
+    # 检查依赖
+    if ! command -v curl &> /dev/null; then
+        error "需要安装 curl"
+        exit 1
+    fi
+    
+    if ! command -v jq &> /dev/null; then
+        error "需要安装 jq"
+        exit 1
+    fi
+    
+    # 解析参数
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -j|--json)
+                method="json"
+                shift
+                ;;
+            -f|--form)
+                method="form"
+                shift
+                ;;
+            -c|--channel)
+                channel="$2"
+                shift 2
+                ;;
+            -p|--pipe)
+                use_pipe=true
+                shift
+                ;;
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            -*)
+                error "未知选项: $1"
+                show_help
+                exit 1
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+    
+    # 处理管道模式
+    if [ "$use_pipe" = true ]; then
+        send_from_pipe "${1:-通知}" "${2:-}"
+        exit $?
+    fi
+    
+    # 检查参数
+    if [ $# -lt 3 ]; then
+        error "参数不足"
+        show_help
+        exit 1
+    fi
+    
+    local title="$1"
+    local description="$2"
+    local content="$3"
+    
+    # 发送消息
+    if [ "$method" = "json" ]; then
+        send_message_json "$title" "$description" "$content" "$channel"
+    else
+        send_message_form "$title" "$description" "$content"
+    fi
+}
+
+# 如果直接运行脚本
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main "$@"
+fi

--- a/examples/bash/test_message_pusher.sh
+++ b/examples/bash/test_message_pusher.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+# Message Pusher 测试脚本
+# 使用简单的测试框架
+
+set -euo pipefail
+
+# 颜色
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# 测试计数
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# 测试函数
+assert_equals() {
+    local expected="$1"
+    local actual="$2"
+    local message="${3:-}"
+    
+    TESTS_RUN=$((TESTS_RUN + 1))
+    
+    if [ "$expected" = "$actual" ]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $message"
+        return 0
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $message"
+        echo -e "  Expected: $expected"
+        echo -e "  Actual:   $actual"
+        return 1
+    fi
+}
+
+assert_success() {
+    local command="$1"
+    local message="${2:-}"
+    
+    TESTS_RUN=$((TESTS_RUN + 1))
+    
+    if eval "$command" > /dev/null 2>&1; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $message"
+        return 0
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $message"
+        return 1
+    fi
+}
+
+assert_failure() {
+    local command="$1"
+    local message="${2:-}"
+    
+    TESTS_RUN=$((TESTS_RUN + 1))
+    
+    if ! eval "$command" > /dev/null 2>&1; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "${GREEN}✓${NC} $message"
+        return 0
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "${RED}✗${NC} $message"
+        return 1
+    fi
+}
+
+# 加载脚本
+source ./message_pusher.sh
+
+echo "开始测试 Message Pusher..."
+echo
+
+# 测试 1: 检查依赖
+echo "测试依赖检查..."
+assert_success "command -v curl" "curl 已安装"
+assert_success "command -v jq" "jq 已安装"
+echo
+
+# 测试 2: 环境变量
+echo "测试环境变量..."
+export MESSAGE_PUSHER_SERVER="http://test.example.com"
+export MESSAGE_PUSHER_USERNAME="testuser"
+export MESSAGE_PUSHER_TOKEN="testtoken"
+
+source ./message_pusher.sh
+
+assert_equals "http://test.example.com" "$MESSAGE_PUSHER_SERVER" "服务器地址设置正确"
+assert_equals "testuser" "$MESSAGE_PUSHER_USERNAME" "用户名设置正确"
+assert_equals "testtoken" "$MESSAGE_PUSHER_TOKEN" "Token 设置正确"
+echo
+
+# 测试 3: 帮助信息
+echo "测试帮助信息..."
+assert_success "./message_pusher.sh --help" "显示帮助信息"
+echo
+
+# 测试 4: 参数解析
+echo "测试参数解析..."
+assert_failure "./message_pusher.sh" "无参数时应失败"
+assert_failure "./message_pusher.sh 标题" "参数不足时应失败"
+assert_failure "./message_pusher.sh 标题 描述" "参数不足时应失败"
+echo
+
+# 测试 5: JSON 数据构建
+echo "测试 JSON 数据构建..."
+json_output=$(jq -n \
+    --arg title "测试标题" \
+    --arg description "测试描述" \
+    --arg content "测试内容" \
+    --arg token "testtoken" \
+    '{title: $title, description: $description, content: $content, token: $token}')
+
+assert_success "echo '$json_output' | jq -e '.title == \"测试标题\"'" "JSON 标题正确"
+assert_success "echo '$json_output' | jq -e '.description == \"测试描述\"'" "JSON 描述正确"
+assert_success "echo '$json_output' | jq -e '.content == \"测试内容\"'" "JSON 内容正确"
+echo
+
+# 显示测试结果
+echo "================================"
+echo "测试完成！"
+echo "总计: $TESTS_RUN"
+echo -e "${GREEN}通过: $TESTS_PASSED${NC}"
+if [ $TESTS_FAILED -gt 0 ]; then
+    echo -e "${RED}失败: $TESTS_FAILED${NC}"
+    exit 1
+else
+    echo -e "${GREEN}✅ 所有测试通过！${NC}"
+    exit 0
+fi


### PR DESCRIPTION
- 添加 message_pusher.sh，支持 JSON 和 Form 请求方式
- 支持从管道读取内容（可集成到系统脚本中）
- 支持指定推送通道和环境变量配置
- 添加完整的单元测试脚本（12 个测试全部通过）
- 彩色输出和详细的错误处理
- 添加完整的 README.md，包含实用示例
- 测试情况：12 个测试全部通过
- 支持 Bash 4.0+，依赖 curl 和 jq
- 可用于系统监控、备份通知、Cron 任务等场景